### PR TITLE
Don't lazy load (creating issues)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,5 @@ Suggests:
     spdep
 License: CC BY-SA 4.0 + file LICENSE
 RoxygenNote: 6.0.1
-LazyData: true
 URL: https://github.com/Nowosad/spData
 BugReports: https://github.com/Nowosad/spData/issues


### PR DESCRIPTION
I'm getting this error message on building the book (but not when run in the repl): 

![image](https://user-images.githubusercontent.com/1825120/28441512-18356526-6da3-11e7-8c8e-fb4720f876e9.png)

Happy for this not to have lazy loading - `world` for example is quite a common object name so I think in some cases loading this package with lazy loading could cause issues but want to check hence the PR.