### PR TITLE
Fix typo

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,7 +14,7 @@
                 msg <- paste("To access larger datasets in this package, install the",
                              "spDataLarge package with:\n",
                              "`install.packages('spDataLarge',", 
-                             "repos='https://nowosad.github.io/drat/', type='source'))`")
+                             "repos='https://nowosad.github.io/drat/', type='source')`")
                 msg <- paste(strwrap(msg), collapse="\n")
                 packageStartupMessage(msg)
         }


### PR DESCRIPTION


Before

``` r
library(spData)
#> To access larger datasets in this package, install the spDataLarge
#> package with: `install.packages('spDataLarge',
#> repos='https://nowosad.github.io/drat/', type='source'))`

install.packages('spDataLarge', repos='https://nowosad.github.io/drat/', type='source'))
# > Error: unexpected ')' in "install.packages('spDataLarge', repos='https://nowosad.github.io/drat/', type='source'))"
```

After

```r
library(spData)
#> To access larger datasets in this package, install the spDataLarge
#> package with: `install.packages('spDataLarge',
#> repos='https://nowosad.github.io/drat/', type='source')`

install.packages('spDataLarge', repos='https://nowosad.github.io/drat/', type='source')
```

Install was successful :)