### PR TITLE
spdep-devel moves sp from depends to suggests

### DIFF
--- a/man/nc.sids.Rd
+++ b/man/nc.sids.Rd
@@ -49,7 +49,7 @@ if (requireNamespace("sf", quietly = TRUE)) {
     library(spdep)
     nc.sids <- sf::st_read(system.file("shapes/sids.shp", package="spData")[1])
     nc.sids <- as(nc.sids, "Spatial")
-    proj4string(nc.sids) <- CRS("+proj=longlat +ellps=clrk66")
+    sp::proj4string(nc.sids) <- sp::CRS("+proj=longlat +ellps=clrk66")
     row.names(nc.sids) <- as.character(nc.sids$FIPS)
     rn <- row.names(nc.sids)
     ncCC89_nb <- read.gal(system.file("weights/ncCC89.gal", package="spData")[1],
@@ -57,10 +57,10 @@ if (requireNamespace("sf", quietly = TRUE)) {
     ncCR85_nb <- read.gal(system.file("weights/ncCR85.gal", package="spData")[1],
                           region.id=rn)
                           
-    plot(nc.sids, border="grey")
-    plot(ncCR85_nb, coordinates(nc.sids), add=TRUE, col="blue")
-    plot(nc.sids, border="grey")
-    plot(ncCC89_nb, coordinates(nc.sids), add=TRUE, col="blue")
+    sp::plot(nc.sids, border="grey")
+    plot(ncCR85_nb, sp::coordinates(nc.sids), add=TRUE, col="blue")
+    sp::plot(nc.sids, border="grey")
+    plot(ncCC89_nb, sp::coordinates(nc.sids), add=TRUE, col="blue")
   }
 }
 }


### PR DESCRIPTION
`man/nc.sids.Rd` uses **sp** without requiring it, because **spdep** has depended on **sp**. This is mis-understood as meaning that only `"Spatial"` objects can be used with **spdep**, so **sp** is moving from `Depends:` to `Suggests:`.